### PR TITLE
Fix for Convergence

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Changelog V 1.0.4.23
+- Fix Convergence breaking if an unit attacks Krathon before turn 17.
+
 Changelog V 1.0.4.22
 - Prevent Dwarves and Elves from attacking the Obelisk in scenario 1
 - Add loss condition of killing the Obelisk in scenario 1

--- a/scenarios/33_Convergence.cfg
+++ b/scenarios/33_Convergence.cfg
@@ -770,7 +770,7 @@
     [/event]
 
     [event]
-        name=turn 17
+        name=turn 17, maat_is_back
 
         [message]
             speaker=Krathon
@@ -1539,6 +1539,10 @@
         [filter_second]
             id=Krathon
         [/filter_second]
+
+        [fire_event]
+            name=maat_is_back
+        [/fire_event]
 
         [message]
             speaker=Krathon


### PR DESCRIPTION
The scenario was breaking if an unit reach Krathon before Maat arrives.
I now force Maat to arrive just before if she has not arrived yet.
I tested that it works.