### PR TITLE
Explicit defeat condition in Lightning and Fire

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+Changelog V 1.0.4.24
+- Inform the player about a defeat condition in Lightning and Fire
+
 Changelog V 1.0.4.23
 - Fix Convergence breaking if an unit attacks Krathon before turn 17.
 

--- a/scenarios/37_Lightning_And_Fire_b.cfg
+++ b/scenarios/37_Lightning_And_Fire_b.cfg
@@ -622,6 +622,10 @@
                 description= _ "Death of Aurvang"
                 condition=lose
             [/objective]
+            [objective]
+                description= _ "Kingu is defeated before Maat and Hathor arrive"
+                condition=lose
+            [/objective]
 
             {TURNS_RUN_OUT}
 
@@ -862,7 +866,7 @@
                 [/hide_unit]
 
                 [message]
-                    speaker=Maat
+                    speaker=Maat,Deinara
                     message= _ "No! We shouldn't have let him escape, now the Asuri will be too strong to be defeated!"
                 [/message]
 

--- a/scenarios/37_Lightning_And_Fire_b.cfg
+++ b/scenarios/37_Lightning_And_Fire_b.cfg
@@ -864,11 +864,23 @@
                 [hide_unit]
                     id=Kingu
                 [/hide_unit]
-
-                [message]
-                    speaker=Maat,Deinara
-                    message= _ "No! We shouldn't have let him escape, now the Asuri will be too strong to be defeated!"
-                [/message]
+                [if]
+                    [have_unit]
+                        id=Maat
+                    [/have_unit]
+                    [then]
+                        [message]
+                            speaker=Maat
+                            message= _ "No! We shouldn't have let him escape, now the Asuri will be too strong to be defeated!"
+                        [/message]
+                    [/then]
+                    [else]
+                        [message]
+                            speaker=Deinara
+                            message= _ "No! We shouldn't have let him escape, now the Asuri will be too strong to be defeated!"
+                        [/message]
+                    [/else]
+                [/if]
 
                 [endlevel]
                     result=defeat


### PR DESCRIPTION
Before, you could lose by killing Kingu without the player knowing it beforehand.